### PR TITLE
Throw error when mongoose connection fails

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,8 @@ mongoose.connect(config.databaseUrl, {
     useUnifiedTopology: true,
     useCreateIndex: true,
     useFindAndModify: false,
-});
+},
+err => {if (err) throw err});
 
 var db = mongoose.connection;
 db.on('error', console.error.bind(console, 'MongoDB connection error:'));


### PR DESCRIPTION
Instead of silently failing to connect, the server throws an error and dies when mongoose connection fails. The output is currently very ugly because it uses the Node error handler, but it works for now.